### PR TITLE
fix(nativewind): Allow manual color scheme changes

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -32,7 +32,11 @@ const RootLayoutNav = () => {
 
   useEffect(() => {
     // Sync NativeWind theme with our custom theme context
-    setColorScheme(effectiveTheme);
+    try {
+      setColorScheme(effectiveTheme);
+    } catch (e) {
+      console.warn('Cannot set color scheme. Is darkMode set to "class"?', e);
+    }
   }, [effectiveTheme]);
 
   useEffect(() => {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,7 @@ module.exports = {
     "./app/**/*.{js,jsx,ts,tsx}",
     "./components/**/*.{js,jsx,ts,tsx}"
   ],
+  darkMode: 'class',
   theme: {
     extend: {},
   },


### PR DESCRIPTION
This commit resolves an issue where manually setting the color scheme using NativeWind's `setColorScheme` would fail.

The root cause was the default Tailwind CSS configuration `darkMode: 'media'`, which forces reliance on the operating system's color scheme and prevents manual overrides.

The fix involves changing this setting to `darkMode: 'class'` in `tailwind.config.js`.

Additionally, a `try...catch` block has been added around the `setColorScheme` call in `app/_layout.tsx` as a safety measure to prevent potential crashes from future misconfigurations.