### PR TITLE
fix: Correct VictoryTheme import to prevent crash

### DIFF
--- a/app/(app)/index.tsx
+++ b/app/(app)/index.tsx
@@ -4,7 +4,8 @@ import { useIncomes } from '../hooks/useIncomes';
 import { useExpenses } from '../hooks/useExpenses';
 import { useDebts } from '../hooks/useDebts';
 import { Ionicons } from '@expo/vector-icons';
-import { VictoryChart, VictoryLine, VictoryTheme, VictoryAxis } from 'victory-native';
+import { VictoryChart, VictoryLine, VictoryAxis } from 'victory-native';
+import { VictoryTheme } from 'victory';
 
 // A simple card component for displaying financial figures
 const FinancialCard = ({ title, value, iconName, color = 'text-gray-900 dark:text-white' }: { title: string, value: string, iconName: any, color?: string }) => (

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "react-native-web": "~0.20.0",
         "react-native-webview": "13.13.5",
         "react-test-renderer": "^19.0.0",
+        "victory": "^37.3.6",
         "victory-native": "^41.17.4",
         "zod": "^4.0.14"
       },
@@ -4838,6 +4839,69 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -7613,6 +7677,12 @@
         "d3-selection": "2 - 3"
       }
     },
+    "node_modules/d3-voronoi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
+      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/d3-zoom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
@@ -7857,6 +7927,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==",
+      "license": "ISC"
+    },
+    "node_modules/delaunay-find": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.6.tgz",
+      "integrity": "sha512-1+almjfrnR7ZamBk0q3Nhg6lqSe6Le4vL0WJDSMx4IDbQwTpUTXPjxC00lqLBT8MYsJpPCbI16sIkw9cPsbi7Q==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "^4.0.0"
       }
     },
     "node_modules/delayed-stream": {
@@ -14682,6 +14767,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -19890,6 +19981,341 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/victory": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory/-/victory-37.3.6.tgz",
+      "integrity": "sha512-CZ1vjvra0R1U3T2dMI4EsjI8Ng+JmQ2ox/EweSzjkTnHfW/Vn5ylryadawDiYjDMcBvABjO3uODsIlSEm4d/Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "victory-area": "37.3.6",
+        "victory-axis": "37.3.6",
+        "victory-bar": "37.3.6",
+        "victory-box-plot": "37.3.6",
+        "victory-brush-container": "37.3.6",
+        "victory-brush-line": "37.3.6",
+        "victory-candlestick": "37.3.6",
+        "victory-canvas": "37.3.6",
+        "victory-chart": "37.3.6",
+        "victory-core": "37.3.6",
+        "victory-create-container": "37.3.6",
+        "victory-cursor-container": "37.3.6",
+        "victory-errorbar": "37.3.6",
+        "victory-group": "37.3.6",
+        "victory-histogram": "37.3.6",
+        "victory-legend": "37.3.6",
+        "victory-line": "37.3.6",
+        "victory-pie": "37.3.6",
+        "victory-polar-axis": "37.3.6",
+        "victory-scatter": "37.3.6",
+        "victory-selection-container": "37.3.6",
+        "victory-shared-events": "37.3.6",
+        "victory-stack": "37.3.6",
+        "victory-tooltip": "37.3.6",
+        "victory-voronoi": "37.3.6",
+        "victory-voronoi-container": "37.3.6",
+        "victory-zoom-container": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-area": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-37.3.6.tgz",
+      "integrity": "sha512-wVC8LKrZJLiSySNuJLRCB449qZTsPiRyzLlNoJwe21y+XA/a2HJbmJSeywmo8P153aX8viKe1H8ygDsTFXQhHw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6",
+        "victory-vendor": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-axis": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-37.3.6.tgz",
+      "integrity": "sha512-Vi0dZvgmXmnCdoqc49WckeG5cMXnl7FTtqVhXu9JweA9cgCnkZabBd5mRvAjblb3Lo4j0HZCSPKHYWUPW70qZg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-bar": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-37.3.6.tgz",
+      "integrity": "sha512-jdATFRWL1LUW/yEpKWx/aId2BiU2o1pPF9+Kh1TFISBduJoI4ZqvZD90H1QK4f/z50PikqiqiDECaKoKM1jfOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6",
+        "victory-vendor": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-box-plot": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-37.3.6.tgz",
+      "integrity": "sha512-GOucnD63h14ScBuISC/nd1GBTEx6gIZfLE+0P0gyeH1poBKq0trTTvpQDvAMuGR8zICfEETG3ltmUMCwRrFyUg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6",
+        "victory-vendor": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-brush-container": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-37.3.6.tgz",
+      "integrity": "sha512-LfZ2CgX1cYAqCtYxcSB68OfZS2v0T2VLXoEArd0lCXfRBY1Gya7GacCUcuo7GoK9XOXeslx7S/U95aVutt1VLg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-brush-line": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-37.3.6.tgz",
+      "integrity": "sha512-zsZJfF1fUj4F7mUoIMV+h73qoTClPA4bKM1terlYrDBD8l/c/f0KBbEotu3E1X+n4QMmDRruswaB/YUdqK5QLA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-candlestick": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-37.3.6.tgz",
+      "integrity": "sha512-h/mOmkCrsWrirn4dFnpLxJPXpxT+uHxuYxnXGrAyH+YUOrVj3iKaDJlEiVlz5vy30syE5j5hzTQCMsZ/hzHNdg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-canvas": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-canvas/-/victory-canvas-37.3.6.tgz",
+      "integrity": "sha512-1CD4S0uZ92sUGGSIEQferEfSqd/z9EXw9G6zkzPIoJeTKFshpfqCjUkNRx9Iu9Upxt3fUpId8Qwl1YfchmbrFg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-bar": "37.3.6",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-chart": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-37.3.6.tgz",
+      "integrity": "sha512-IkPo/W4AJ7bPu902TGER09OseR9ODm+FQAKfOBw4JsdEhZZ7BiG9zgd/25+x0r5EsTLu81CYGQVkBa+ZazcOlA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-axis": "37.3.6",
+        "victory-core": "37.3.6",
+        "victory-polar-axis": "37.3.6",
+        "victory-shared-events": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-core": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-37.3.6.tgz",
+      "integrity": "sha512-aFgO6KokxPbUCPznZP5UPhOdI22pMuwDXKDt6eoQOnkVim66Ia+K95TQar2nwVKGYV5j26aKVf/n9blwphGJRw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "react-fast-compare": "^3.2.0",
+        "victory-vendor": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-create-container": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-37.3.6.tgz",
+      "integrity": "sha512-Uf5bFQvqUsXCjqpvBW4LhrdrHkM6dBqxYgub6FCsBb86f84xZQ3vY7jFkg/JfvF0oGKMoWXYYrYLC1sk+fcWVA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-brush-container": "37.3.6",
+        "victory-core": "37.3.6",
+        "victory-cursor-container": "37.3.6",
+        "victory-selection-container": "37.3.6",
+        "victory-voronoi-container": "37.3.6",
+        "victory-zoom-container": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-cursor-container": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-37.3.6.tgz",
+      "integrity": "sha512-+Oiw57d5nE+iq8As8RvepknzmNtKq1Gsc50u1X3IRd4jXtX8zqZrgXGlVZ+BP/tkLsWnGYVjKulwKBf2oaEUuw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-errorbar": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-37.3.6.tgz",
+      "integrity": "sha512-WGAv/qizOlfmwKv+Yfxr4q6pDgTfloNQwi3Z3M0h8povjMZt74tHYkvi/TASSRYr3zv5kjUqUJ28qAyGMWwryQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-group": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-37.3.6.tgz",
+      "integrity": "sha512-kgy/Azl5BxwlJAV0KDPGypv35TMrOD1J2ZxnJW2Wyyq+e8i0GGBIv5MoBzou64BRsDlS9V0CYRIjnkHgrBpB5w==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "37.3.6",
+        "victory-shared-events": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-histogram": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-37.3.6.tgz",
+      "integrity": "sha512-K4d43MpXHYnGCLEMzfRpJ+lCRRDKALPi/juxfMGVzBPzSMgjC8h9x6hKdxaejiTd/E04UdzNO7J24plL3Uz8rA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-bar": "37.3.6",
+        "victory-core": "37.3.6",
+        "victory-vendor": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-legend": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-37.3.6.tgz",
+      "integrity": "sha512-vRRrhj3/ENqKVLdaBMzEmR83N6BOjox1bthYT1eJjN2H5SIK35bxn30IkiV/Pz3y627EqZe4TAWaxc0jiJlCiA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-line": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-37.3.6.tgz",
+      "integrity": "sha512-Ke817uf/qFbN9jU7Dba7CrcHXYO5wAZuKKnyeHJmLDeQeFST0773xejnIuC+dBgZipjFr4KIbSd+VcUafFNE1g==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6",
+        "victory-vendor": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
     "node_modules/victory-native": {
       "version": "41.17.4",
       "resolved": "https://registry.npmjs.org/victory-native/-/victory-native-41.17.4.tgz",
@@ -19908,6 +20334,197 @@
         "react-native": "*",
         "react-native-gesture-handler": ">=2.0.0",
         "react-native-reanimated": ">=3.0.0"
+      }
+    },
+    "node_modules/victory-pie": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-37.3.6.tgz",
+      "integrity": "sha512-tvdgAZ/HQWlo3KDDe0XAVbizHuaNMbgkkiF7zfA7Ww+3bHSs+0P9dsDtK2xP365D8gBCOv8pWmuzvKRhzNbqeA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6",
+        "victory-vendor": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-polar-axis": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-37.3.6.tgz",
+      "integrity": "sha512-RpFsCkzHezJq5P+C/wtVdjEHX25JIFsSgs6qYSnfr/hayaFbWgK5HhRFpriQm5hg61cx47WxAOLyHvzf0nasvw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-scatter": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-37.3.6.tgz",
+      "integrity": "sha512-fp95zMTPXgW1cmTowzDXhn+KxePMVDrzU0lotsHQMdBV7eB+ioXdu9hORlx4VHmMYg2ihsGwRTF+VAZ7rGxphA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-selection-container": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-37.3.6.tgz",
+      "integrity": "sha512-gd3qODDlBtLEJM7+2jCXk2YcLBUmIpYEEHswytMhwc6zihxXipGBUHRulhLj/I05mKay2gaOAg5ewiJHd4Awgw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-shared-events": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-37.3.6.tgz",
+      "integrity": "sha512-ygrbOtzLUTbtKebacZKyQRekhSAROnAvMkVI/PKsAGsz0ClY9P7qDEJG7eTUUygjO6ax0tI6WNE6JogQzeD1gw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-stack": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-37.3.6.tgz",
+      "integrity": "sha512-ldod04RdqGJGH5p5eWXCofdTkbhZqIp3iwW7NpxSbMDLs8zPQIVvDFVtuJgMwQiC5vnIpbhMmxVeFbr8m64ZKA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "37.3.6",
+        "victory-shared-events": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-tooltip": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-37.3.6.tgz",
+      "integrity": "sha512-vqaJS9noauOqDDBBAV9Ln9duOY/i17h1DCfCPAqhwPFyvFbwKvAub9zPTeYWAm/14VvWX5O/0yekFCVbcC7hjg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/victory-voronoi": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-37.3.6.tgz",
+      "integrity": "sha512-Q+1FWHp8IAbmDL9pGWS0y0N4Cb5qmD9OOgxoxCfIDsLlhGvd6LddhRoknWsN7WnreaK+XiwjSfQkdMTCZ4hdhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-voronoi": "^1.1.4",
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-voronoi-container": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-37.3.6.tgz",
+      "integrity": "sha512-qAAG0rMuK7A4EoJ4cyUk5wNdOW+HuCXNKPOko+hYK6wWOYXJvFhiglYyA85a695YyAXECc6JyJS/crm4IOEFag==",
+      "license": "MIT",
+      "dependencies": {
+        "delaunay-find": "0.0.6",
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "37.3.6",
+        "victory-tooltip": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-zoom-container": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-37.3.6.tgz",
+      "integrity": "sha512-AGL+k20mI44OL5b0VgIxlmnNSefIoFmbbim5NraPmIxbtns9qQW/56ivIncJcYomBungIx99gUpsEpcQaMNHgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
       }
     },
     "node_modules/vlq": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
     "react-test-renderer": "^19.0.0",
+    "victory": "^37.3.6",
     "victory-native": "^41.17.4",
     "zod": "^4.0.14"
   },


### PR DESCRIPTION
The VictoryChart component was causing a TypeError because `VictoryTheme` was being imported from `victory-native`, where it is no longer exported.

This change updates the import to pull `VictoryTheme` from the `victory` package, which resolves the runtime error. It also adds the `victory` package as a direct dependency.