### PR TITLE
Fix import paths for hooks and components

### DIFF
--- a/app/(app)/assets.tsx
+++ b/app/(app)/assets.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useMemo } from 'react';
 import { View, Text, FlatList, ActivityIndicator, Pressable, Alert } from 'react-native';
-import { useAssets, useDeleteAsset, Asset } from '../hooks/useAssets';
+import { useAssets, useDeleteAsset, Asset } from '~/hooks/useAssets';
 import { Ionicons } from '@expo/vector-icons';
-import { AddEditAssetModal } from '../components/AddEditAssetModal';
+import { AddEditAssetModal } from '~/components/AddEditAssetModal';
 import { useQueryClient } from '@tanstack/react-query';
-import { useAuth } from '../contexts/AuthContext';
-import { useAssetPrices } from '../hooks/useAssetPrices';
+import { useAuth } from '~/contexts/AuthContext';
+import { useAssetPrices } from '~/hooks/useAssetPrices';
 
 const AssetListItem = ({ item, price, onEdit, onDelete }: { item: Asset, price: number | undefined, onEdit: (asset: Asset) => void, onDelete: (assetId: string) => void }) => {
     const value = price ? item.amount * price : null;

--- a/app/(app)/expenses.tsx
+++ b/app/(app)/expenses.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { View, Text, FlatList, ActivityIndicator, Pressable, Alert } from 'react-native';
-import { useExpenses, useDeleteExpense, Expense } from '../hooks/useExpenses';
+import { useExpenses, useDeleteExpense, Expense } from '~/hooks/useExpenses';
 import { Ionicons } from '@expo/vector-icons';
-import { AddEditExpenseModal } from '../components/AddEditExpenseModal';
+import { AddEditExpenseModal } from '~/components/AddEditExpenseModal';
 
 const ExpenseListItem = ({ item, onEdit, onDelete }: { item: Expense, onEdit: (expense: Expense) => void, onDelete: (expenseId: string) => void }) => (
   <View className="bg-white dark:bg-gray-800 p-4 rounded-lg mb-4 shadow-sm">

--- a/app/(app)/explore.tsx
+++ b/app/(app)/explore.tsx
@@ -1,12 +1,12 @@
 import { Image } from 'expo-image';
 import { Platform, StyleSheet } from 'react-native';
 
-import { Collapsible } from '~/components/Collapsible';
-import { ExternalLink } from '~/components/ExternalLink';
-import ParallaxScrollView from '~/components/ParallaxScrollView';
-import { ThemedText } from '~/components/ThemedText';
-import { ThemedView } from '~/components/ThemedView';
-import { IconSymbol } from '~/components/ui/IconSymbol';
+import { Collapsible } from '@/components/Collapsible';
+import { ExternalLink } from '@/components/ExternalLink';
+import ParallaxScrollView from '@/components/ParallaxScrollView';
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import { IconSymbol } from '@/components/ui/IconSymbol';
 
 export default function TabTwoScreen() {
   return (

--- a/app/(app)/income.tsx
+++ b/app/(app)/income.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { View, Text, FlatList, ActivityIndicator, Pressable, Alert } from 'react-native';
-import { useIncomes, useDeleteIncome, Income } from '../hooks/useIncomes';
+import { useIncomes, useDeleteIncome, Income } from '~/hooks/useIncomes';
 import { Ionicons } from '@expo/vector-icons';
-import { AddEditIncomeModal } from '../components/AddEditIncomeModal';
+import { AddEditIncomeModal } from '~/components/AddEditIncomeModal';
 
 // The list item component now includes Edit and Delete buttons
 const IncomeListItem = ({ item, onEdit, onDelete }: { item: Income, onEdit: (income: Income) => void, onDelete: (incomeId: string) => void }) => (

--- a/app/(app)/index.tsx
+++ b/app/(app)/index.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo, useState } from 'react';
 import { View, Text, ScrollView, ActivityIndicator, RefreshControl } from 'react-native';
-import { useIncomes } from '../hooks/useIncomes';
-import { useExpenses } from '../hooks/useExpenses';
-import { useDebts } from '../hooks/useDebts';
+import { useIncomes } from '~/hooks/useIncomes';
+import { useExpenses } from '~/hooks/useExpenses';
+import { useDebts } from '~/hooks/useDebts';
 import { Ionicons } from '@expo/vector-icons';
 import {
   VictoryChart,

--- a/app/(app)/settings.tsx
+++ b/app/(app)/settings.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { View, Text, Pressable, Switch, Alert, ActivityIndicator } from 'react-native';
-import { useSettings, useUpdateSettings, Theme } from '../hooks/useSettings';
-import { useTheme } from '../contexts/ThemeContext';
-import { useAuth } from '../contexts/AuthContext';
+import { useSettings, useUpdateSettings, Theme } from '~/hooks/useSettings';
+import { useTheme } from '~/contexts/ThemeContext';
+import { useAuth } from '~/contexts/AuthContext';
 
 const SettingRow = ({ label, children }: { label: string, children: React.ReactNode }) => (
   <View className="flex-row justify-between items-center p-4 bg-white dark:bg-gray-800 rounded-lg mb-4">

--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -1,4 +1,4 @@
-import { supabase } from '../lib/supabaseClient';
+import { supabase } from '~/lib/supabaseClient';
 import { Link, useRouter } from 'expo-router';
 import React, { useState } from 'react';
 import { useForm, Controller } from 'react-hook-form';

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -1,4 +1,4 @@
-import { supabase } from '../lib/supabaseClient';
+import { supabase } from '~/lib/supabaseClient';
 import { Link } from 'expo-router';
 import React, { useState } from 'react';
 import { useForm, Controller } from 'react-hook-form';

--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -1,8 +1,8 @@
 import { Link, Stack } from 'expo-router';
 import { StyleSheet } from 'react-native';
 
-import { ThemedText } from '~/components/ThemedText';
-import { ThemedView } from '~/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
 
 export default function NotFoundScreen() {
   return (

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,11 +1,11 @@
-import { AuthProvider, useAuth } from './contexts/AuthContext';
+import { AuthProvider, useAuth } from '~/contexts/AuthContext';
 import { ThemeProvider as NavThemeProvider, DarkTheme, DefaultTheme } from '@react-navigation/native';
-import { ThemeProvider as CustomThemeProvider, useTheme } from './contexts/ThemeContext';
+import { ThemeProvider as CustomThemeProvider, useTheme } from '~/contexts/ThemeContext';
 import { Stack, useRouter, useSegments } from 'expo-router';
 import { useEffect } from 'react';
 import { ActivityIndicator, View } from 'react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { QueueProcessor } from './components/QueueProcessor';
+import { QueueProcessor } from '~/components/QueueProcessor';
 import Toast from 'react-native-toast-message';
 const queryClient = new QueryClient();
 

--- a/app/debts/[id].tsx
+++ b/app/debts/[id].tsx
@@ -1,9 +1,9 @@
 import React, { useMemo, useState } from 'react';
 import { View, Text, FlatList, ActivityIndicator, Pressable } from 'react-native';
 import { useLocalSearchParams, Stack } from 'expo-router';
-import { useDebts, DebtAmountHistory } from '../hooks/useDebts';
+import { useDebts, DebtAmountHistory } from '~/hooks/useDebts';
 import { Ionicons } from '@expo/vector-icons';
-import { RecordPaymentModal } from '../components/RecordPaymentModal';
+import { RecordPaymentModal } from '~/components/RecordPaymentModal';
 
 const HistoryListItem = ({ item, change }: { item: DebtAmountHistory, change: number }) => {
     const isIncrease = change > 0;

--- a/components/Collapsible.tsx
+++ b/components/Collapsible.tsx
@@ -1,9 +1,9 @@
 import { PropsWithChildren, useState } from 'react';
 import { StyleSheet, TouchableOpacity } from 'react-native';
 
-import { ThemedText } from '~/components/ThemedText';
-import { ThemedView } from '~/components/ThemedView';
-import { IconSymbol } from '~/components/ui/IconSymbol';
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import { IconSymbol } from '@/components/ui/IconSymbol';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 

--- a/components/HelloWave.tsx
+++ b/components/HelloWave.tsx
@@ -8,7 +8,7 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 
-import { ThemedText } from '~/components/ThemedText';
+import { ThemedText } from '@/components/ThemedText';
 
 export function HelloWave() {
   const rotationAnimation = useSharedValue(0);

--- a/components/ParallaxScrollView.tsx
+++ b/components/ParallaxScrollView.tsx
@@ -7,8 +7,8 @@ import Animated, {
   useScrollViewOffset,
 } from 'react-native-reanimated';
 
-import { ThemedView } from '~/components/ThemedView';
-import { useBottomTabOverflow } from '~/components/ui/TabBarBackground';
+import { ThemedView } from '@/components/ThemedView';
+import { useBottomTabOverflow } from '@/components/ui/TabBarBackground';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
 const HEADER_HEIGHT = 250;


### PR DESCRIPTION
## Summary
- correct imports of hooks/components using project aliases
- switch component imports to root alias `@`
- update auth screens to use `~/lib`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688c92bd82a4833290f104afd6575cd7