### PR TITLE
fix(app): Correct unbalanced JSX in Dashboard

### DIFF
--- a/app/(app)/index.tsx
+++ b/app/(app)/index.tsx
@@ -144,6 +144,7 @@ export default function Dashboard() {
 
         <View className="bg-white dark:bg-gray-800 rounded-2xl p-4 shadow-sm mt-4">
           <Text className="text-lg font-semibold text-gray-600 dark:text-gray-400 mb-2">Monthly Cash Flow</Text>
+          <VictoryChart theme={VictoryThemeMaterial} height={220}>
             <VictoryAxis
               style={{
                 axis: { stroke: 'none' },

--- a/src/victoryTheme.ts
+++ b/src/victoryTheme.ts
@@ -1,7 +1,7 @@
-import { material } from 'victory-native/lib/theme';
+import { VictoryTheme } from 'victory-native';
 
 /**
  * Re-export of the Victory “material” theme for React-Native.
  * Usage:  import { VictoryThemeMaterial } from '~/victoryTheme';
  */
-export const VictoryThemeMaterial = material;
+export const VictoryThemeMaterial = VictoryTheme.material;


### PR DESCRIPTION
The `VictoryChart` component in the main dashboard screen was missing its opening tag, causing TypeScript compilation and Metro to fail.

This change adds the opening `<VictoryChart>` tag to correctly wrap the chart's axes and line plots.

Additionally, a related issue in `src/victoryTheme.ts` was discovered and fixed. The import path for the Victory Native theme was outdated. This has been updated to the correct import from `victory-native` directly, ensuring the theme is applied correctly.